### PR TITLE
Fix a deadlock in logging

### DIFF
--- a/wedge/settings.py
+++ b/wedge/settings.py
@@ -23,9 +23,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'asdadasdasd'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -160,11 +160,14 @@ LOGGING = {
         #     'filters': [],
         #     'class': 'logging.StreamHandler',
         # },
-        # 'null': {
-        #     'class': 'logging.NullHandler',
-        # },
+        'null': {
+            'class': 'logging.NullHandler',
+        },
     },
     'loggers': {
+        'django': {
+            'handlers': ['null']
+        }
     },
 }
 


### PR DESCRIPTION
Problem was caused by an handler without any reference and the deadlock
is caused during the garbage collection phase. Removing all unused
handlers fix the problem.